### PR TITLE
aqua: remove mise

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -17,6 +17,5 @@ packages:
 - name: suzuki-shunsuke/pinact@v1.2.1
 - name: suzuki-shunsuke/ghalint@v1.2.3
 - name: rhysd/actionlint@v1.7.7
-- name: jdx/mise@v2025.2.9
 - name: google/go-jsonnet@v0.20.0
 - name: earthly/earthly@v0.8.15


### PR DESCRIPTION
Sometimes mise installed by aqua waste cpu when launch VSCode at my windows PC (WSL2).
I don't know why this happen, so I try install mise by homebrew.